### PR TITLE
fix(ci): skip Snyk and Sonar when tokens are unset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,17 +160,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check Sonar token
+        id: sonar
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          if [ -z "${SONAR_TOKEN}" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::SONAR_TOKEN not set. Configure SonarCloud per PLAYBOOK.md (Pré-requisitos manuais)."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: SonarCloud Scan
-        if: ${{ secrets.SONAR_TOKEN != '' }}
+        if: steps.sonar.outputs.enabled == 'true'
         uses: SonarSource/sonarcloud-github-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-      - name: Skip Sonar (SONAR_TOKEN not configured)
-        if: ${{ secrets.SONAR_TOKEN == '' }}
-        run: |
-          echo "::warning::SONAR_TOKEN not set. Configure SonarCloud per PLAYBOOK.md §10 (Onda 1)."
 
   unit:
     name: Unit tests (Vitest)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,64 +182,71 @@ jobs:
   unit:
     name: Unit tests (Vitest)
     runs-on: ubuntu-latest
-    if: ${{ hashFiles('package.json') != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
       - name: Setup Node
+        if: ${{ hashFiles('package.json') != '' }}
         uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm
 
       - name: Install dependencies
+        if: ${{ hashFiles('package.json') != '' }}
         run: npm ci
 
       - name: Run unit tests with coverage
+        if: ${{ hashFiles('package.json') != '' }}
         run: npm run test:unit --if-present
 
   mutation:
     name: Mutation tests (Stryker)
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && hashFiles('package.json') != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
       - name: Setup Node
+        if: ${{ github.event_name == 'pull_request' && hashFiles('package.json') != '' }}
         uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm
 
       - name: Install dependencies
+        if: ${{ github.event_name == 'pull_request' && hashFiles('package.json') != '' }}
         run: npm ci
 
       - name: Run mutation tests
+        if: ${{ github.event_name == 'pull_request' && hashFiles('package.json') != '' }}
         run: npm run test:mutation --if-present
 
   integration:
     name: Integration tests (Playwright)
     runs-on: ubuntu-latest
-    if: ${{ hashFiles('package.json') != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
       - name: Setup Node
+        if: ${{ hashFiles('package.json') != '' }}
         uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm
 
       - name: Install dependencies
+        if: ${{ hashFiles('package.json') != '' }}
         run: npm ci
 
       - name: Install Playwright browsers
+        if: ${{ hashFiles('package.json') != '' }}
         run: npx playwright install --with-deps chromium
 
       - name: Run e2e tests
+        if: ${{ hashFiles('package.json') != '' }}
         run: npm run test:e2e --if-present
 
   ci-success:

--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -26,7 +26,20 @@ jobs:
       - name: Install Snyk CLI
         uses: snyk/actions/setup@master
 
+      - name: Check Snyk token
+        id: snyk
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          if [ -z "${SNYK_TOKEN}" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::SNYK_TOKEN not set. Configure Snyk per PLAYBOOK.md (Pré-requisitos manuais)."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Snyk Code
+        if: steps.snyk.outputs.enabled == 'true'
         run: snyk code test --severity-threshold=medium
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Summary

- Fixes Snyk Code auth failure (`SNYK-0005`) when `SNYK_TOKEN` is not configured
- Fixes CI workflow failing to start (0 jobs) due to `secrets` used in `if` conditionals on Sonar steps

## Root cause

`SNYK_TOKEN` is empty in repo secrets → Snyk returned 401.

Separately, `if: ${{ secrets.* }}` in workflow steps invalidates the workflow file (GitHub does not allow `secrets` in `if`), which explains recent CI runs with **0 jobs**.

## Fix

Probe token in a shell step, expose `enabled` output, gate scan step on `steps.*.outputs.enabled == 'true'`.

LGPD-OK — CI-only change.

## Test plan

- [ ] Snyk workflow completes with warning when token unset
- [ ] CI workflow starts all jobs (lint-html, a11y, etc.)
- [ ] Sonar step skipped with warning when `SONAR_TOKEN` unset

Made with [Cursor](https://cursor.com)